### PR TITLE
Add sensor validation service

### DIFF
--- a/services/influxDbPersistanceService.js
+++ b/services/influxDbPersistanceService.js
@@ -1,4 +1,4 @@
-const {InfluxDB, Point} = require('@influxdata/influxdb-client')
+const {InfluxDB, Point, flux, fluxDuration} = require('@influxdata/influxdb-client')
 
 const client = new InfluxDB({
     url: process.env.INFLUX_HOST,
@@ -7,6 +7,7 @@ const client = new InfluxDB({
 
 
 const writeApi = client.getWriteApi(process.env.INFLUX_ORGANIZATION, process.env.INFLUX_BUCKET, 's')
+const queryApi = client.getQueryApi(process.env.INFLUX_ORGANIZATION)
 
 async function saveMeasurement(measurement){
     const point = new Point('climate')
@@ -17,8 +18,20 @@ async function saveMeasurement(measurement){
         .floatField(measurement.parameter, measurement.value)
 
     writeApi.writePoint(point)
-
+    writeApi.flush();
 }
 
+function getSensorEntries(location, start = '-5m', end = '0m'){
 
-module.exports = {saveMeasurement}
+    const query = flux`
+        from(bucket: "${process.env.INFLUX_BUCKET}") 
+        |> range(start: ${fluxDuration(start)}, stop: ${fluxDuration(end)})
+        |> filter(fn: (r) => r._measurement == "climate"
+                                and r.loc_x == "${location.loc_x}" 
+                                and r.loc_y == "${location.loc_y}" 
+                                and r.floor == "${location.floor}")
+    `
+    return queryApi.collectRows(query)
+}
+
+module.exports = {saveMeasurement, getSensorEntries}

--- a/services/sensorValidationService.js
+++ b/services/sensorValidationService.js
@@ -1,0 +1,35 @@
+const { getSensorEntries } = require("./influxDbPersistanceService")
+
+/**
+ * Acknowledges a faulty entry and returns false if the associated sensor should be considered faulty otherwise true
+ * @param {{loc_x: number, loc_y: number, floor: number}} measurement the measuremnt that is considered falses
+ * @returns false if associated sensor is considered faulty and true otherwise
+ */
+async function reportFaultyMeasurement(measurement){
+    let entries = await getSensorEntries(measurement, '-5m', '0m')
+
+    let counter = { true: 0, false: 0} 
+    entries.forEach(entry => counter[entry.is_valid]++)
+
+    if( tooManyInvalidEntries(counter) || notEnoughValidEntries(counter)){
+        console.log("Sensor Invalid!")
+        console.log(Date().toString())
+        console.log({measurement, counter})
+        return false
+    }
+
+    return true
+}
+
+function tooManyInvalidEntries(counter){ return counter.false > 0 }
+
+const MIN_ENTRIES_PER_5_MINUTES = 19 // temperature and hummidity, twice a minute, five minutes, one wrong is okay
+
+function notEnoughValidEntries(counter){ 
+    return counter.true < MIN_ENTRIES_PER_5_MINUTES && IsServerUpFor5Minutes()
+}
+
+// 5 minutes = 5 min * 60 sec * 10^9 nanosec
+function IsServerUpFor5Minutes(){ return process.uptime() > 5 * 60 * 1e+9}
+
+module.exports = {reportFaultyMeasurement}

--- a/services/sensorValidationService.js
+++ b/services/sensorValidationService.js
@@ -1,4 +1,4 @@
-const { getSensorEntries } = require("./influxDbPersistanceService")
+const { getSensorEntries } = require('./influxDbPersistanceService')
 
 /**
  * Acknowledges a faulty entry and returns false if the associated sensor should be considered faulty otherwise true

--- a/tests/sensorValidationService.test.js
+++ b/tests/sensorValidationService.test.js
@@ -5,6 +5,17 @@ const {getSensorEntries} = require('../services/influxDbPersistanceService')
 
 const service = require('../services/sensorValidationService')
 
+
+let sampleInvalidEntry
+
+beforeAll(() =>{
+    sampleInvalidEntry ={
+        loc_x: 10,
+        loc_y: 10,
+        floor: 11,
+    }
+})
+
 test('exists', () =>{
     expect(service.reportFaultyMeasurement).toBeTruthy()
 })
@@ -13,11 +24,7 @@ test('Report first faulty entry results in true', async () => {
 
     getSensorEntries.mockResolvedValue([])
 
-    expect(await service.reportFaultyMeasurement({
-        loc_x: 10,
-        loc_y: 10,
-        floor: 11,
-    })).toBeTruthy()
+    expect(await service.reportFaultyMeasurement(sampleInvalidEntry)).toBeTruthy()
 })
 
 test('one faulty entry + more valid entries results in true', async () => {
@@ -29,11 +36,7 @@ test('one faulty entry + more valid entries results in true', async () => {
         {is_valid: 'true'},
     ])
 
-    expect(await service.reportFaultyMeasurement({
-        loc_x: 10,
-        loc_y: 10,
-        floor: 11,
-    })).toBeTruthy()
+    expect(await service.reportFaultyMeasurement(sampleInvalidEntry)).toBeTruthy()
 })
 
 test('The correct coordinates are being requested', async () => {
@@ -44,6 +47,8 @@ test('The correct coordinates are being requested', async () => {
         loc_x: 1,
         loc_y: 2,
         floor: 11,
+        value: 25,
+        paramaeter: 'temperature',
     })
 
     const requestedLoc = getSensorEntries.mock.calls[0][0]
@@ -53,18 +58,67 @@ test('The correct coordinates are being requested', async () => {
     expect(requestedLoc.floor).toBe(11)
 })
 
-
-
-
 test('Report second faulty entry results in false', async () => {
 
     getSensorEntries.mockResolvedValue([
         {is_valid: 'false'}
     ])
 
-    expect(await service.reportFaultyMeasurement({
-        loc_x: 10,
-        loc_y: 10,
-        floor: 11,
-    })).toBeFalsy()
+    expect(await service.reportFaultyMeasurement(sampleInvalidEntry)).toBeFalsy()
+})
+
+describe('Tests when uptime of server is > 5min', () => {
+    beforeEach( () => {
+        jest.spyOn(process, 'uptime').mockImplementation(() => 6 * 60 * 1e9) // 6 minutes
+    })
+
+    test('Report first faulty entry results in false', async () => {
+
+        getSensorEntries.mockResolvedValue([])
+    
+        expect(await service.reportFaultyMeasurement(sampleInvalidEntry)).toBe(false)
+    })
+
+    test('one faulty entry + four valid entries results in false', async () => {
+
+        getSensorEntries.mockResolvedValue([
+            {is_valid: 'true'},
+            {is_valid: 'true'},
+            {is_valid: 'true'},
+            {is_valid: 'true'},
+        ])
+    
+        expect(await service.reportFaultyMeasurement(sampleInvalidEntry)).toBe(false)
+    })
+
+    test('one faulty entry + 18 valid entries results in false', async () => {
+
+        getSensorEntries.mockResolvedValue(new Array(18).fill({is_valid: 'true'}))
+    
+        expect(await service.reportFaultyMeasurement(sampleInvalidEntry)).toBe(false)
+    })
+
+    test('one faulty entry + 19 valid entries results in true', async () => {
+
+        getSensorEntries.mockResolvedValue(new Array(19).fill({is_valid: 'true'}))
+    
+        expect(await service.reportFaultyMeasurement(sampleInvalidEntry)).toBe(true)
+    })
+
+    test('one faulty entry + 20 valid entries results in true', async () => {
+
+        getSensorEntries.mockResolvedValue(new Array(20).fill({is_valid: 'true'}))
+    
+        expect(await service.reportFaultyMeasurement(sampleInvalidEntry)).toBe(true)
+    })
+
+    test('one faulty entry + 18 valid + 1 invalid results in false', async () => {
+
+        const EntryCacheMock = new Array(19).fill({is_valid: 'true'})
+        EntryCacheMock.push({is_valid: false})
+
+        getSensorEntries.mockResolvedValue(EntryCacheMock)
+    
+        expect(await service.reportFaultyMeasurement(sampleInvalidEntry)).toBe(false)
+    })
 })

--- a/tests/sensorValidationService.test.js
+++ b/tests/sensorValidationService.test.js
@@ -1,0 +1,70 @@
+jest.mock('../services/influxDbPersistanceService')
+jest.mock('@influxdata/influxdb-client')
+
+const {getSensorEntries} = require('../services/influxDbPersistanceService')
+
+const service = require('../services/sensorValidationService')
+
+test('exists', () =>{
+    expect(service.reportFaultyMeasurement).toBeTruthy()
+})
+
+test('Report first faulty entry results in true', async () => {
+
+    getSensorEntries.mockResolvedValue([])
+
+    expect(await service.reportFaultyMeasurement({
+        loc_x: 10,
+        loc_y: 10,
+        floor: 11,
+    })).toBeTruthy()
+})
+
+test('one faulty entry + more valid entries results in true', async () => {
+
+    getSensorEntries.mockResolvedValue([
+        {is_valid: 'true'},
+        {is_valid: 'true'},
+        {is_valid: 'true'},
+        {is_valid: 'true'},
+    ])
+
+    expect(await service.reportFaultyMeasurement({
+        loc_x: 10,
+        loc_y: 10,
+        floor: 11,
+    })).toBeTruthy()
+})
+
+test('The correct coordinates are being requested', async () => {
+
+    getSensorEntries.mockResolvedValue([])
+
+    await service.reportFaultyMeasurement({
+        loc_x: 1,
+        loc_y: 2,
+        floor: 11,
+    })
+
+    const requestedLoc = getSensorEntries.mock.calls[0][0]
+
+    expect(requestedLoc.loc_x).toBe(1)
+    expect(requestedLoc.loc_y).toBe(2)
+    expect(requestedLoc.floor).toBe(11)
+})
+
+
+
+
+test('Report second faulty entry results in false', async () => {
+
+    getSensorEntries.mockResolvedValue([
+        {is_valid: 'false'}
+    ])
+
+    expect(await service.reportFaultyMeasurement({
+        loc_x: 10,
+        loc_y: 10,
+        floor: 11,
+    })).toBeFalsy()
+})


### PR DESCRIPTION
service exposes only one method that should be called each time a faulty entry is detected. Upon calling that method the service will query more entries for that specific sensor in the last 5 minutes and decide whether or not the sensor is faulty.